### PR TITLE
Adiciona duplos para a correta substituição

### DIFF
--- a/Cebolinha.cs
+++ b/Cebolinha.cs
@@ -11,8 +11,10 @@ namespace Cebolinha
 			string Frase = Console.ReadLine();
 			Console.Clear();
 			string Cebolinha = Frase
-			    .Replace("r" , "l")
-			    .Replace("R" , "L");
+			    .Replace("rr" , "l")
+			    .Replace("r" , "l")				
+			    .Replace("RR" , "L");
+		            .Replace("R" , "L");
 			Console.WriteLine(Cebolinha);
         }
     }


### PR DESCRIPTION
Dado que o usuário digite "Ferreira":

Dado:

Ferreira.

"Ferreira"..Replace("r", "l").Replace("R","L")
"Felleila", pois, o primeiro replace ("r") substituiu tudo.

Com a correção:
"Ferreira"..Replace("rr", "l").Replace("r","l").Replace("RR","L").Replace("R","L")
"Feleila", pois, o primeiro replace ("rr") substituiu apenas o duplo r.